### PR TITLE
myGenecis.jsのconfigフィールドに値追加

### DIFF
--- a/first_use/connect_to_private_net.md
+++ b/first_use/connect_to_private_net.md
@@ -27,7 +27,16 @@ $ mkdir /home/ubuntu/eth_private_net
 ```javascript
 {
   "config": {
-    "chainId": 15
+    "chainId": 15,
+    "homesteadBlock": 0,
+    "eip150Block": 0,
+    "eip155Block": 0,
+    "eip158Block": 0,
+    "byzantiumBlock": 0,
+    "constantinopleBlock": 0,
+    "petersburgBlock": 0,
+    "istanbulBlock": 0,
+    "berlinBlock": 0
   },
   "nonce": "0x0000000000000042",
   "timestamp": "0x0",


### PR DESCRIPTION
チュートリアルを進めていると「etherを送金する」の章でコマンドに失敗しました

```
> eth.sendTransaction({from: eth.accounts[0], to: eth.accounts[1], value: web3.toWei(5, "ether")})
Error: invalid sender
        at web3.js:6357:37(47)
        at web3.js:5091:62(37)
        at <eval>:1:20(21)
```

myGenecis.jsを修正し再度`init`することで問題なく動作しました

```
geth --datadir ./eth_private_net init ./eth_private_net/myGenesis.json
```